### PR TITLE
showcase products

### DIFF
--- a/db/query.sql
+++ b/db/query.sql
@@ -12,6 +12,43 @@ WHERE
     10000
   );
 
+-- Get stores within a radius from a point with products available as JSON array
+SELECT
+  stores.store_id,
+  stores.name,
+  stores.address,
+  stores.geog,
+  stores.created_at,
+  stores.updated_at,
+  ARRAY_AGG(
+    JSON_BUILD_OBJECT(
+      'name',
+      products.name,
+      'id',
+      products.product_id,
+      'brand',
+      products.brand,
+      'createdAt',
+      products.created_at,
+      'updatedAt',
+      products.updated
+    )
+  ) AS products
+FROM
+  stores
+  JOIN stores_products ON stores_products.stores_store_id = stores.store_id
+  JOIN products ON stores_products.products_product_id = products.product_id
+WHERE
+  ST_DWithin (
+    geog,
+    -- LONDON
+    ST_GeographyFromText ('POINT(-0.1275 51.50722)'),
+    -- METRES
+    10000
+  )
+GROUP BY
+  stores.store_id;
+
 -- Get stores within a radius from a point and product name
 SELECT
   -- Avoid duplicates
@@ -128,5 +165,43 @@ FROM
   stores
   JOIN stores_products ON stores_products.stores_store_id = stores.store_id
   JOIN products ON stores_products.products_product_id = products.product_id
+GROUP BY
+  stores.store_id;
+
+-- 
+SELECT
+  stores.store_id,
+  stores.name,
+  stores.address,
+  stores.geog,
+  stores.created_at,
+  stores.updated_at,
+  ARRAY_AGG(
+    JSON_BUILD_OBJECT(
+      'name',
+      products.name,
+      'id',
+      products.product_id,
+      'brand',
+      products.brand,
+      'createdAt',
+      products.created_at,
+      'updatedAt',
+      products.updated
+    )
+  ) AS products
+FROM
+  stores
+  JOIN stores_products ON stores_products.stores_store_id = stores.store_id
+  JOIN products ON stores_products.products_product_id = products.product_id
+WHERE
+  products.reference = 'PAN'
+  AND ST_DWithin (
+    geog,
+    -- LONDON
+    ST_GeographyFromText ('POINT(-0.1275 51.50722)'),
+    -- METRES
+    5000
+  )
 GROUP BY
   stores.store_id;

--- a/db/query.sql
+++ b/db/query.sql
@@ -1,3 +1,4 @@
+-- Get stores within a radius from a point
 SELECT
   *
 FROM
@@ -11,6 +12,7 @@ WHERE
     10000
   );
 
+-- Get stores within a radius from a point and product name
 SELECT
   -- Avoid duplicates
   DISTINCT ON (store_id) stores.geog,
@@ -38,7 +40,7 @@ WHERE
     10000
   );
 
--- Get stores with products as JSON array
+-- Get store with products as JSON array
 SELECT
   stores.store_id,
   stores.name,
@@ -66,5 +68,65 @@ FROM
   JOIN products ON stores_products.stores_store_id = '<STORE_ID>'
 WHERE
   stores.store_id = '<STORE_ID>'
+GROUP BY
+  stores.store_id;
+
+-- Select store by ID and returns an array of products
+SELECT
+  stores.store_id,
+  stores.name,
+  stores.address,
+  stores.geog,
+  stores.created_at,
+  stores.updated_at,
+  ARRAY_AGG(
+    JSON_BUILD_OBJECT(
+      'name',
+      products.name,
+      'id',
+      products.product_id,
+      'brand',
+      products.brand,
+      'createdAt',
+      products.created_at,
+      'updatedAt',
+      products.updated
+    )
+  ) AS products
+FROM
+  stores
+  JOIN stores_products ON stores_products.stores_store_id = stores.store_id
+  JOIN products ON stores_products.products_product_id = products.product_id
+WHERE
+  stores.store_id = '7956e435-df1b-465b-a052-6004ed14fe08'
+GROUP BY
+  stores.store_id;
+
+-- Select all stores and return an array of products
+SELECT
+  stores.store_id,
+  stores.name,
+  stores.address,
+  stores.geog,
+  stores.created_at,
+  stores.updated_at,
+  ARRAY_AGG(
+    JSON_BUILD_OBJECT(
+      'name',
+      products.name,
+      'id',
+      products.product_id,
+      'brand',
+      products.brand,
+      'createdAt',
+      products.created_at,
+      'updatedAt',
+      products.updated
+    )
+  ) AS products
+FROM
+  stores
+  JOIN stores_products ON stores_products.stores_store_id = stores.store_id
+  JOIN products ON stores_products.products_product_id = products.product_id
 GROUP BY
   stores.store_id;

--- a/db/query.sql
+++ b/db/query.sql
@@ -37,3 +37,34 @@ WHERE
     -- METRES
     10000
   );
+
+-- Get stores with products as JSON array
+SELECT
+  stores.store_id,
+  stores.name,
+  stores.address,
+  stores.geog,
+  stores.created_at,
+  stores.updated_at,
+  ARRAY_AGG(
+    JSON_BUILD_OBJECT(
+      'name',
+      products.name,
+      'id',
+      products.product_id,
+      'brand',
+      products.brand,
+      'createdAt',
+      products.created_at,
+      'updatedAt',
+      products.updated
+    )
+  ) products
+FROM
+  stores
+  JOIN stores_products ON stores_products.stores_store_id = '<STORE_ID>'
+  JOIN products ON stores_products.stores_store_id = '<STORE_ID>'
+WHERE
+  stores.store_id = '<STORE_ID>'
+GROUP BY
+  stores.store_id;

--- a/db/query.sql
+++ b/db/query.sql
@@ -12,7 +12,7 @@ WHERE
     10000
   );
 
--- Get stores within a radius from a point with products available as JSON array
+-- Get stores within a radius from a point with products available as an array
 SELECT
   stores.store_id,
   stores.name,
@@ -23,7 +23,7 @@ SELECT
   ARRAY_AGG(
     JSON_BUILD_OBJECT(
       'name',
-      products.name,
+      products.reference,
       'id',
       products.product_id,
       'brand',
@@ -49,159 +49,70 @@ WHERE
 GROUP BY
   stores.store_id;
 
--- Get stores within a radius from a point and product name
+-- Get stores within a radius from a point where product is with products available as an array
 SELECT
-  -- Avoid duplicates
-  DISTINCT ON (store_id) stores.geog,
+  stores.store_id,
   stores.name,
   stores.address,
+  stores.geog,
   stores.created_at,
-  stores.updated_at
+  stores.updated_at,
+  ARRAY_AGG(
+    JSON_BUILD_OBJECT(
+      'name',
+      products.reference,
+      'id',
+      products.product_id,
+      'brand',
+      products.brand,
+      'createdAt',
+      products.created_at,
+      'updatedAt',
+      products.updated
+    )
+  ) AS products
 FROM
-  stores -- Many to many by joint table
-  JOIN stores_products ON stores_products.products_product_id = (
-    SELECT
-      products.product_id
-    FROM
-      products
-    WHERE
-      reference = 'COCOSETTE'
-  )
-  JOIN products ON stores_products.stores_store_id = store_id
+  stores
+  JOIN stores_products ON stores_products.stores_store_id = stores.store_id
+  JOIN products ON stores_products.products_product_id = products.product_id
 WHERE
-  ST_DWithin (
+  products.reference = '<PRODUCT REFERENCE>' ST_DWithin (
     geog,
     -- LONDON
     ST_GeographyFromText ('POINT(-0.1275 51.50722)'),
     -- METRES
     10000
-  );
-
--- Get store with products as JSON array
-SELECT
-  stores.store_id,
-  stores.name,
-  stores.address,
-  stores.geog,
-  stores.created_at,
-  stores.updated_at,
-  ARRAY_AGG(
-    JSON_BUILD_OBJECT(
-      'name',
-      products.name,
-      'id',
-      products.product_id,
-      'brand',
-      products.brand,
-      'createdAt',
-      products.created_at,
-      'updatedAt',
-      products.updated
-    )
-  ) products
-FROM
-  stores
-  JOIN stores_products ON stores_products.stores_store_id = '<STORE_ID>'
-  JOIN products ON stores_products.stores_store_id = '<STORE_ID>'
-WHERE
-  stores.store_id = '<STORE_ID>'
-GROUP BY
-  stores.store_id;
-
--- Select store by ID and returns an array of products
-SELECT
-  stores.store_id,
-  stores.name,
-  stores.address,
-  stores.geog,
-  stores.created_at,
-  stores.updated_at,
-  ARRAY_AGG(
-    JSON_BUILD_OBJECT(
-      'name',
-      products.name,
-      'id',
-      products.product_id,
-      'brand',
-      products.brand,
-      'createdAt',
-      products.created_at,
-      'updatedAt',
-      products.updated
-    )
-  ) AS products
-FROM
-  stores
-  JOIN stores_products ON stores_products.stores_store_id = stores.store_id
-  JOIN products ON stores_products.products_product_id = products.product_id
-WHERE
-  stores.store_id = '7956e435-df1b-465b-a052-6004ed14fe08'
-GROUP BY
-  stores.store_id;
-
--- Select all stores and return an array of products
-SELECT
-  stores.store_id,
-  stores.name,
-  stores.address,
-  stores.geog,
-  stores.created_at,
-  stores.updated_at,
-  ARRAY_AGG(
-    JSON_BUILD_OBJECT(
-      'name',
-      products.name,
-      'id',
-      products.product_id,
-      'brand',
-      products.brand,
-      'createdAt',
-      products.created_at,
-      'updatedAt',
-      products.updated
-    )
-  ) AS products
-FROM
-  stores
-  JOIN stores_products ON stores_products.stores_store_id = stores.store_id
-  JOIN products ON stores_products.products_product_id = products.product_id
-GROUP BY
-  stores.store_id;
-
--- 
-SELECT
-  stores.store_id,
-  stores.name,
-  stores.address,
-  stores.geog,
-  stores.created_at,
-  stores.updated_at,
-  ARRAY_AGG(
-    JSON_BUILD_OBJECT(
-      'name',
-      products.name,
-      'id',
-      products.product_id,
-      'brand',
-      products.brand,
-      'createdAt',
-      products.created_at,
-      'updatedAt',
-      products.updated
-    )
-  ) AS products
-FROM
-  stores
-  JOIN stores_products ON stores_products.stores_store_id = stores.store_id
-  JOIN products ON stores_products.products_product_id = products.product_id
-WHERE
-  products.reference = 'PAN'
-  AND ST_DWithin (
-    geog,
-    -- LONDON
-    ST_GeographyFromText ('POINT(-0.1275 51.50722)'),
-    -- METRES
-    5000
   )
 GROUP BY
   stores.store_id;
+
+-- Get store by ID with an array of products available
+SELECT
+  stores.store_id,
+  stores.name,
+  stores.address,
+  stores.geog,
+  stores.created_at,
+  stores.updated_at,
+  ARRAY_AGG(
+    JSON_BUILD_OBJECT(
+      'name',
+      products.reference,
+      'id',
+      products.product_id,
+      'brand',
+      products.brand,
+      'createdAt',
+      products.created_at,
+      'updatedAt',
+      products.updated
+    )
+  ) AS products
+FROM
+  stores
+  JOIN stores_products ON stores_products.stores_store_id = stores.store_id
+  JOIN products ON stores_products.products_product_id = products.product_id
+WHERE
+  stores.store_id = '<STORE ID>'
+GROUP BY
+  stores.store_id

--- a/projects/server/__generated__/resolvers-types.ts
+++ b/projects/server/__generated__/resolvers-types.ts
@@ -82,6 +82,7 @@ export type Store = {
   createdAt?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['ID']>;
   name?: Maybe<Scalars['String']>;
+  products?: Maybe<Array<Product>>;
   updatedAt?: Maybe<Scalars['String']>;
 };
 
@@ -322,6 +323,11 @@ export type StoreResolvers<
   >;
   id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  products?: Resolver<
+    Maybe<Array<ResolversTypes['Product']>>,
+    ParentType,
+    ContextType
+  >;
   updatedAt?: Resolver<
     Maybe<ResolversTypes['String']>,
     ParentType,

--- a/projects/server/db/migrations/0002-products-table.sql
+++ b/projects/server/db/migrations/0002-products-table.sql
@@ -4,7 +4,7 @@ CREATE TABLE products (
   reference varchar(255) NOT NULL UNIQUE,
   brand varchar(255),
   created_at timestamp NOT NULL DEFAULT (now()),
-  updated timestamp NOT NULL DEFAULT (current_timestamp)
+  updated_at timestamp NOT NULL DEFAULT (current_timestamp)
 );
 
 COMMENT ON TABLE stores IS 'Stores stores locations';

--- a/projects/server/models/store/get-store-by-id.ts
+++ b/projects/server/models/store/get-store-by-id.ts
@@ -40,15 +40,28 @@ export const getStoreById = async (
       stores.geog,
       stores.created_at,
       stores.updated_at,
-      ARRAY_AGG(JSON_BUILD_OBJECT('name', products.reference, 'id', products.product_id, 'brand', products.brand, 'createdAt', products.created_at, 'updatedAt', products.updated)) products
+      ARRAY_AGG(
+        JSON_BUILD_OBJECT(
+          'name',
+          products.reference,
+          'id',
+          products.product_id,
+          'brand',
+          products.brand,
+          'createdAt',
+          products.created_at,
+          'updatedAt',
+          products.updated
+        )
+      ) AS products
     FROM
       stores
-      JOIN stores_products ON stores_products.stores_store_id = '${id}'
-      JOIN products ON stores_products.stores_store_id = '${id}'
+      JOIN stores_products ON stores_products.stores_store_id = stores.store_id
+      JOIN products ON stores_products.products_product_id = products.product_id
     WHERE
       stores.store_id = '${id}'
     GROUP BY
-      stores.store_id;`,
+        stores.store_id`,
   );
 
   return fromSqlToStore(rows[0]);

--- a/projects/server/models/store/get-store-by-id.ts
+++ b/projects/server/models/store/get-store-by-id.ts
@@ -33,7 +33,22 @@ export const getStoreById = async (
   }
 
   const { rows }: { rows: StoreRow[] } = await query(
-    `SELECT * from stores WHERE store_id = '${id}'`,
+    `SELECT
+      stores.store_id,
+      stores.name,
+      stores.address,
+      stores.geog,
+      stores.created_at,
+      stores.updated_at,
+      ARRAY_AGG(JSON_BUILD_OBJECT('name', products.reference, 'id', products.product_id, 'brand', products.brand, 'createdAt', products.created_at, 'updatedAt', products.updated)) products
+    FROM
+      stores
+      JOIN stores_products ON stores_products.stores_store_id = '${id}'
+      JOIN products ON stores_products.stores_store_id = '${id}'
+    WHERE
+      stores.store_id = '${id}'
+    GROUP BY
+      stores.store_id;`,
   );
 
   return fromSqlToStore(rows[0]);

--- a/projects/server/models/store/get-store-by-id.ts
+++ b/projects/server/models/store/get-store-by-id.ts
@@ -51,7 +51,7 @@ export const getStoreById = async (
           'createdAt',
           products.created_at,
           'updatedAt',
-          products.updated
+          products.updated_at
         )
       ) AS products
     FROM

--- a/projects/server/models/store/get-stores-from.ts
+++ b/projects/server/models/store/get-stores-from.ts
@@ -68,7 +68,7 @@ export const getStoresFrom = async (
             'createdAt',
             products.created_at,
             'updatedAt',
-            products.updated
+            products.updated_at
           )
         ) AS products
       FROM
@@ -107,7 +107,7 @@ export const getStoresFrom = async (
           'createdAt',
           products.created_at,
           'updatedAt',
-          products.updated
+          products.updated_at
         )
       ) AS products
     FROM

--- a/projects/server/models/store/get-stores-from.ts
+++ b/projects/server/models/store/get-stores-from.ts
@@ -27,14 +27,9 @@ const getStoresFromSchema = Joi.object({
 
 export const getStoresFrom = async (
   _parent: unknown,
-  {
-    from: { distance, coordinates, product },
-  }: // from: { distance, coordinates, product = ProductName.Pan },
-  GetStoresFromArgs,
+  { from: { distance, coordinates, product } }: GetStoresFromArgs,
 ) => {
   const { lat, lng } = coordinates;
-
-  console.log({ product });
 
   const { error } = getStoresFromSchema.validate({
     distance,

--- a/projects/server/models/store/shared.ts
+++ b/projects/server/models/store/shared.ts
@@ -1,4 +1,5 @@
 import { Geometry } from 'wkx';
+
 import {
   Product,
   ProductName,

--- a/projects/server/models/store/shared.ts
+++ b/projects/server/models/store/shared.ts
@@ -14,7 +14,7 @@ interface ProductFromStoreRow {
   name: string;
   brand: string;
   createdAt: string;
-  updated: string;
+  updatedAt: string;
 }
 
 export interface StoreRow {
@@ -43,14 +43,20 @@ export const fromSqlToStore = ({
   const [lng, lat] = coordinates;
 
   const productSerialised: Product[] = products.map((product) => {
-    const { id: productId, brand, name, createdAt, updated } = product;
+    const {
+      id: productId,
+      brand,
+      name,
+      createdAt: productCreatedAt,
+      updatedAt: productUpdatedAt,
+    } = product;
 
     return {
       id: productId,
       name: name as ProductName,
       brand,
-      createdAt,
-      updatedAt: updated,
+      createdAt: new Date(productCreatedAt).valueOf().toString(),
+      updatedAt: new Date(productUpdatedAt).valueOf().toString(),
     };
   });
 

--- a/projects/server/models/store/shared.ts
+++ b/projects/server/models/store/shared.ts
@@ -1,8 +1,20 @@
-import { Store } from '../../__generated__/resolvers-types';
 import { Geometry } from 'wkx';
+import {
+  Product,
+  ProductName,
+  Store,
+} from '../../__generated__/resolvers-types';
 
 export interface GeoJson {
   coordinates: [number, number];
+}
+
+interface ProductFromStoreRow {
+  id: string;
+  name: string;
+  brand: string;
+  createdAt: string;
+  updated: string;
 }
 
 export interface StoreRow {
@@ -12,6 +24,7 @@ export interface StoreRow {
   address: string;
   created_at: string;
   updated_at: string;
+  products: ProductFromStoreRow[];
 }
 
 export const fromSqlToStore = ({
@@ -21,12 +34,25 @@ export const fromSqlToStore = ({
   address,
   created_at: createdAt,
   updated_at: updatedAt,
+  products,
 }: StoreRow) => {
   const { coordinates } = Geometry.parse(
     Buffer.from(geog, 'hex'),
   ).toGeoJSON() as GeoJson;
 
   const [lng, lat] = coordinates;
+
+  const productSerialised: Product[] = products.map((product) => {
+    const { id: productId, brand, name, createdAt, updated } = product;
+
+    return {
+      id: productId,
+      name: name as ProductName,
+      brand,
+      createdAt,
+      updatedAt: updated,
+    };
+  });
 
   const store: Store = {
     id,
@@ -38,6 +64,7 @@ export const fromSqlToStore = ({
     },
     createdAt,
     updatedAt,
+    products: productSerialised,
   };
 
   return store;

--- a/projects/server/schema.graphql
+++ b/projects/server/schema.graphql
@@ -11,6 +11,7 @@ type Store {
   name: String
   createdAt: String
   updatedAt: String
+  products: [Product!]
 }
 
 enum ProductName {

--- a/projects/server/tests/stores-query.test.ts
+++ b/projects/server/tests/stores-query.test.ts
@@ -133,22 +133,94 @@ describe('Query stores', () => {
     const variables = {
       from: {
         coordinates,
-        distance: 5000,
+        distance: 10000,
       },
     };
 
     const expected = [
       {
+        name: 'Brixton Market',
+      },
+      {
+        name: 'Piccolo Bar',
+      },
+      {
+        name: 'El Rincon Quiteno',
+      },
+      {
         name: 'Arepa & Co',
+      },
+      {
+        name: 'Jeans Deli/Cafe',
+      },
+      {
+        name: 'Sun Food',
+      },
+      {
+        name: 'Casa de Carnes',
+      },
+      {
+        name: 'Rye Lane',
+      },
+      {
+        name: 'Afro Caribbean Asian Store',
+      },
+      {
+        name: 'La Chatica',
+      },
+      {
+        name: 'Latin Stop',
+      },
+      {
+        name: 'Tesco Tottenham',
+      },
+      {
+        name: 'Fulham',
+      },
+      {
+        name: 'Tesco Extra Streatham',
+      },
+      {
+        name: 'Tropical Mini Market',
       },
       {
         name: 'Los Arrieros',
       },
       {
+        name: 'M.k. Super Market',
+      },
+      {
+        name: 'K M Butchers',
+      },
+      {
+        name: 'Supermecardo Portugal',
+      },
+      {
         name: 'La Bodeguita',
       },
       {
-        name: 'La Chatica',
+        name: 'Tesco',
+      },
+      {
+        name: 'Tahir Halal Meat',
+      },
+      {
+        name: 'Seven Sisters Greengrocers',
+      },
+      {
+        name: 'Tesco Lewisham Superstore',
+      },
+      {
+        name: 'R Garcia and Sons',
+      },
+      {
+        name: 'Gurbet',
+      },
+      {
+        name: 'Donde Carlos',
+      },
+      {
+        name: 'International Cash & Carry',
       },
     ].sort(sortAlphaByName);
 

--- a/projects/server/tests/stores-query.test.ts
+++ b/projects/server/tests/stores-query.test.ts
@@ -123,7 +123,7 @@ describe('Query stores', () => {
     expect(stores.sort(sortAlphaByName)).toEqual(expected);
   });
 
-  it('Get stores by distances and product PAN when product is not given', async () => {
+  it('Get stores by distances product is not given', async () => {
     const query = `query Stores($from: StoresFromInput!) {
                         stores(from: $from) {
                           name
@@ -221,6 +221,87 @@ describe('Query stores', () => {
       },
       {
         name: 'International Cash & Carry',
+      },
+    ].sort(sortAlphaByName);
+
+    const response = await server.executeOperation({
+      query,
+      variables,
+    });
+
+    const {
+      body: {
+        // @ts-ignore
+        singleResult: {
+          errors,
+          data: { stores },
+        },
+      },
+    } = response;
+
+    expect(errors).toBeUndefined();
+    expect(stores.sort(sortAlphaByName)).toEqual(expected);
+  });
+
+  it('return a stores with a list of products available', async () => {
+    const query = `
+      query Stores($from: StoresFromInput!) {
+        stores(from: $from) {
+          name
+          products {
+            name
+          }
+        }
+      }`;
+
+    const variables = {
+      from: {
+        coordinates,
+        distance: 5000,
+      },
+    };
+
+    const expected = [
+      {
+        name: 'La Bodeguita',
+        products: [
+          {
+            name: 'PAN',
+          },
+          {
+            name: 'COCOSETTE',
+          },
+        ],
+      },
+      {
+        name: 'Los Arrieros',
+        products: [
+          {
+            name: 'PAN',
+          },
+          {
+            name: 'COCOSETTE',
+          },
+        ],
+      },
+      {
+        name: 'La Chatica',
+        products: [
+          {
+            name: 'COCOSETTE',
+          },
+          {
+            name: 'PAN',
+          },
+        ],
+      },
+      {
+        name: 'Arepa & Co',
+        products: [
+          {
+            name: 'PAN',
+          },
+        ],
       },
     ].sort(sortAlphaByName);
 

--- a/projects/server/tests/stores-query.test.ts
+++ b/projects/server/tests/stores-query.test.ts
@@ -303,7 +303,16 @@ describe('Query stores', () => {
           },
         ],
       },
-    ].sort(sortAlphaByName);
+    ]
+      .sort(sortAlphaByName)
+      .map((store) => {
+        const orderedProducts = store.products.sort(sortAlphaByName);
+
+        return {
+          ...store,
+          products: orderedProducts,
+        };
+      });
 
     const response = await server.executeOperation({
       query,
@@ -321,6 +330,16 @@ describe('Query stores', () => {
     } = response;
 
     expect(errors).toBeUndefined();
-    expect(stores.sort(sortAlphaByName)).toEqual(expected);
+    expect(
+      stores
+        .sort(sortAlphaByName)
+        .map((store: { products: { name: string }[] }) => {
+          const orderedProducts = store.products.sort(sortAlphaByName);
+          return {
+            ...store,
+            products: orderedProducts,
+          };
+        }),
+    ).toEqual(expected);
   });
 });


### PR DESCRIPTION
- Return stores from Query Stores when  product is not available
- Remove default value on product when query stores
- Add products to store response
- Add query example
- Add query examples that return stores with a column products
- Fix query from model getStoreById
- Change getStoresFrom DB query to return an array of available products
- Update SQL query reference
- Test if stores are coming with products
- Test that stores brings products as an array and fix updated_at column in products table
